### PR TITLE
Fix bundle filename parsing for versions

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -76,15 +76,13 @@ impl Bundle {
             .ok_or(BundleFromError::OsStrToStrFailed)?
             .to_string();
 
-        let format = path
-            .drain(path.rfind('.').ok_or(BundleFromError::FormatFailed)? + 1..)
-            .collect::<String>();
-        let version = path
-            .drain(path.rfind("-v").ok_or(BundleFromError::VersionFailed)? + 2..path.len() - 1)
-            .collect::<String>();
-        let id = path
-            .drain(..path.rfind("-v").ok_or(BundleFromError::IDFailed)?)
-            .collect::<String>();
+        let format_index = path.rfind('.').ok_or(BundleFromError::FormatFailed)?;
+        let format = path[format_index + 1..].to_string();
+        path.truncate(format_index);
+
+        let version_index = path.rfind("-v").ok_or(BundleFromError::VersionFailed)?;
+        let version = path[version_index + 2..].to_string();
+        let id = path[..version_index].to_string();
 
         if format.is_empty() {
             return Err(BundleFromError::FormatFailed);


### PR DESCRIPTION
### Motivation
- The `Bundle::from_filename` parser could leave a trailing `.` in the version string (when extracting with `drain` ranges), causing `Version::parse` to fail and breaking `utils::archive::unzip` tests.

### Description
- Update `src/bundle.rs` in `Bundle::from_filename` to strip the file extension first with `rfind('.')` and `truncate`, then extract the `-v` version slice and ID via index-based slicing instead of `drain`, preventing leftover characters in the parsed version.

### Testing
- Ran `cargo test`; before the change `utils::archive::test_unzip` failed with a `Version::parse` error, and after the fix all unit tests and doctests passed when running `cargo test` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811c52c9308326bd90bfd2535a8e8b)